### PR TITLE
Add sample routing files

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -12,7 +12,8 @@
         "flowbite": "^1.6.4",
         "flowbite-react": "^0.4.2",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "react-router-dom": "^6.11.1"
       },
       "devDependencies": {
         "@babel/core": "^7.21.4",
@@ -2821,6 +2822,14 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.6.1.tgz",
+      "integrity": "sha512-YUkWj+xs0oOzBe74OgErsuR3wVn+efrFhXBWrit50kOiED+pvQe2r6MWY0iJMQU/mSVKxvNzL4ZaYvjdX+G7ZA==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -9614,6 +9623,36 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.11.1.tgz",
+      "integrity": "sha512-OZINSdjJ2WgvAi7hgNLazrEV8SGn6xrKA+MkJe9wVDMZ3zQ6fdJocUjpCUCI0cNrelWjcvon0S/QK/j0NzL3KA==",
+      "dependencies": {
+        "@remix-run/router": "1.6.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.11.1.tgz",
+      "integrity": "sha512-dPC2MhoPeTQ1YUOt5uIK376SMNWbwUxYRWk2ZmTT4fZfwlOvabF8uduRKKJIyfkCZvMgiF0GSCQckmkGGijIrg==",
+      "dependencies": {
+        "@remix-run/router": "1.6.1",
+        "react-router": "6.11.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/read-cache": {

--- a/client/package.json
+++ b/client/package.json
@@ -13,11 +13,12 @@
     "format": "prettier --write 'src/**/*.{js,jsx,ts,tsx,css,md,json}' --config ./.prettierrc"
   },
   "dependencies": {
+    "eslint-plugin-react-hooks": "^4.6.0",
     "flowbite": "^1.6.4",
     "flowbite-react": "^0.4.2",
-    "eslint-plugin-react-hooks": "^4.6.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.11.1"
   },
   "devDependencies": {
     "@babel/core": "^7.21.4",
@@ -36,8 +37,6 @@
     "@typescript-eslint/parser": "^5.57.1",
     "@vitejs/plugin-react": "^3.1.0",
     "autoprefixer": "^10.4.14",
-    "postcss": "^8.4.21",
-    "tailwindcss": "^3.3.1",
     "babel-jest": "^29.5.0",
     "babel-preset-react-app": "^10.0.1",
     "eslint": "^8.37.0",
@@ -54,6 +53,8 @@
     "jest-css-modules-transform": "^4.4.2",
     "jest-environment-jsdom": "^29.5.0",
     "jest-watch-typeahead": "^2.2.2",
+    "postcss": "^8.4.21",
+    "tailwindcss": "^3.3.1",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.3",
     "vite": "^4.2.0"

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,7 +1,12 @@
+import Home from "./pages/Home";
+import {Route, Routes} from "react-router-dom";
+
 function App(): JSX.Element {
   return (
-    <div className="text-2xl text-rose-600">
-      Hello World
+    <div>
+      <Routes>
+          <Route path={"/"} element={ <Home/> } />
+      </Routes>
     </div>
   )
 }

--- a/client/src/components/header.tsx
+++ b/client/src/components/header.tsx
@@ -1,0 +1,15 @@
+/**
+ * Sample Component (Replace if you find its usage anywhere in the project)
+ * */
+import React from "react";
+import {type HeaderType} from "../utils/types";
+
+const Header = ({id, name}: HeaderType): JSX.Element => {
+    return (
+        <div className="header" key={id}>
+            <h1>{name}</h1>
+        </div>
+    )
+}
+
+export default Header;

--- a/client/src/hooks/useHeader.tsx
+++ b/client/src/hooks/useHeader.tsx
@@ -1,0 +1,8 @@
+import {useState} from "react";
+
+const useHeader = () => {
+    const [header, setHeader] = useState<string>()
+    return {header, setHeader}
+}
+
+export default useHeader;

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -2,9 +2,12 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App'
 import './index.css'
+import { BrowserRouter } from "react-router-dom";
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <App />
+      <BrowserRouter>
+            <App />
+      </BrowserRouter>
   </React.StrictMode>,
 )

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -1,0 +1,19 @@
+import Header from "../components/header";
+import useHeader from "../hooks/useHeader";
+import {useEffect} from "react";
+
+const Home = (): JSX.Element => {
+
+    const {header, setHeader} = useHeader();
+    useEffect(() => {
+        setHeader("Home Page")
+    }, [setHeader])
+
+    return (
+        <div>
+            <Header id={1} name={header ?? "This is the home page!"}/>
+        </div>
+    );
+}
+
+export default Home;

--- a/client/src/utils/types.ts
+++ b/client/src/utils/types.ts
@@ -1,0 +1,5 @@
+// Sample Type
+export interface HeaderType {
+    id: number;
+    name: string;
+}


### PR DESCRIPTION
This PR contains the following:

- Add the `react-router-dom` library.
- Add sample `component`
- Add sample `page`
- Add sample `hook`
- Add sample `type`
- Add Routes